### PR TITLE
Added dist.requires() to check for package dependencies

### DIFF
--- a/gaenv/__init__.py
+++ b/gaenv/__init__.py
@@ -80,7 +80,13 @@ def parse_requirements(pypi_requirements, cvs_requirements):
                 except pkg_resources.DistributionNotFound:
                     print 'Please install [%s]' % requirement
     # end repo temp fix
-    return requirements
+
+    full_requirements = []
+    for req in requirements:
+        full_requirements.append(req)
+        full_requirements.extend(pkg_resources.get_provider(req).requires())
+
+    return full_requirements
 
 
 def compute_package_links(requirements):


### PR DESCRIPTION
Hey! This needs more work but I just wanted to bring it to your attention. From my understanding,             links.extend(dist.get_metadata_lines('dependency_links.txt')) is supposed to add the dependencies of the packages in requirements.txt in the gaenv_lib directory, but it didn't work in my case (e.g. for Flask). I found this dirty workaround and thought it was worth sharing. Cheers :)