### PR TITLE
fix docopt spacing

### DIFF
--- a/gaenv/__init__.py
+++ b/gaenv/__init__.py
@@ -5,10 +5,10 @@ Utility to create python package symlinks for deployment in GAE. Before running 
 Usage: gaenv [options]
 
 Options:
-    -r --requirements=FILE		Specify the requirements  [default: requirements.txt]
-    -l --lib=DIR                        Change the the output dir [default: gaenv_lib]
-    -n --no-import			Will not add import statement to appengine_config.py
-    -c --copy				Copy libraries instead of symlinking
+    -r --requirements=FILE      Specify the requirements  [default: requirements.txt]
+    -l --lib=DIR                Change the the output dir [default: gaenv_lib]
+    -n --no-import              Will not add import statement to appengine_config.py
+    -c --copy                   Copy libraries instead of symlinking
 """
 from distutils.sysconfig import get_python_lib
 from docopt import docopt


### PR DESCRIPTION
Docopt (or at least 0.6.2) seems to have issues with parsing tabs.

Here's a test case with tabs (both literal and escapes for posterity, though they parse the same) and spaces

``` python
doc_with_tab_escapes = """
Some doc

Usage: test.py [options]

  -s --switch\t\tA sweet switch
"""

doc_with_tab_literals = """
Some doc

Usage: test.py [options]

  -s --switch       A sweet switch
"""

doc_with_spaces = """
Some doc

Usage: test.py [options]

  -s --switch       A sweet switch
"""

docs = [
    ('tab escapes "\\t"', doc_with_tab_escapes),
    ('tab literals', doc_with_tab_literals), 
    ('spaces', doc_with_spaces)
]

import docopt
for name, doc in docs:
    print 'Testing', name
    print repr(doc)
    try:
        docopt.docopt(doc, argv=['-s'])
        print 'OK'
    except docopt.DocoptExit as e:
        print 'FAIL', e
    print
```

```
Testing tab escapes "\t"
'\nSome doc\n\nUsage: test.py [options]\n\n  -s --switch\t\tA sweet switch\n'
FAIL -s requires argument
Usage: test.py [options]

Testing tab literals
'\nSome doc\n\nUsage: test.py [options]\n\n  -s --switch\t\tA sweet switch\n'
FAIL -s requires argument
Usage: test.py [options]

Testing spaces
'\nSome doc\n\nUsage: test.py [options]\n\n  -s --switch       A sweet switch\n'
OK
```

This pull request removes tabs from docstring option lines and aligns them with spaces instead.
